### PR TITLE
Add browser-based memory companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Memory-App
+# Memory Companion
+
+Memory Companion is a lightweight journal designed to help people with memory
+loss capture daily events and revisit them whenever they need a reminder. The
+app runs entirely in the browser and keeps entries stored locally so they are
+always within reach.
+
+## Features
+
+- Capture key information for each memory: date, time, title and details.
+- Quickly jump to any day with the date picker or search for keywords across
+  all entries.
+- Entries are stored in the browser via `localStorage`, meaning they remain
+  available even after the page is closed.
+- Export the full list of memories as JSON to share with care partners or back
+  up your data.
+
+## Getting started
+
+Open `index.html` in any modern browser. No build steps or external services
+are required.
+
+For the best experience, add new memories shortly after they happen and review
+previous days in the evening.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Memory Companion</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Memory Companion</h1>
+      <p class="tagline">
+        Capture your daily moments so you can revisit them whenever you need a
+        gentle reminder.
+      </p>
+    </header>
+
+    <main>
+      <section class="form-card" aria-labelledby="add-event-title">
+        <h2 id="add-event-title">Add a new memory</h2>
+        <form id="event-form">
+          <div class="form-group">
+            <label for="event-date">Date</label>
+            <input type="date" id="event-date" name="eventDate" required />
+          </div>
+          <div class="form-group">
+            <label for="event-time">Time</label>
+            <input type="time" id="event-time" name="eventTime" />
+          </div>
+          <div class="form-group">
+            <label for="event-title">Title</label>
+            <input
+              type="text"
+              id="event-title"
+              name="eventTitle"
+              placeholder="Breakfast with Alex"
+              maxlength="80"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="event-details">Details</label>
+            <textarea
+              id="event-details"
+              name="eventDetails"
+              rows="4"
+              placeholder="We met at the park and talked about the weekend plans."
+            ></textarea>
+          </div>
+          <div class="form-actions">
+            <button type="submit">Save memory</button>
+            <button type="button" id="reset-form" class="secondary">
+              Clear
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="history-card" aria-labelledby="history-title">
+        <div class="history-header">
+          <div>
+            <h2 id="history-title">Memory history</h2>
+            <p class="history-subtitle">
+              Select a date to revisit what happened.
+            </p>
+          </div>
+          <div class="controls">
+            <label class="controls__label" for="filter-date">Go to date</label>
+            <input type="date" id="filter-date" />
+            <label class="controls__label" for="search-text">Search</label>
+            <input
+              type="search"
+              id="search-text"
+              placeholder="Type a word like 'doctor'"
+              aria-label="Search memories"
+            />
+            <button type="button" id="export-events" class="secondary">
+              Export
+            </button>
+          </div>
+        </div>
+        <div id="history-list" class="history-list" aria-live="polite"></div>
+        <template id="event-template">
+          <article class="event-card">
+            <header>
+              <h3 class="event-title"></h3>
+              <time class="event-time"></time>
+            </header>
+            <p class="event-details"></p>
+          </article>
+        </template>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Tip: try adding memories as soon as they happen. Reviewing them each
+        evening can reinforce your day.
+      </p>
+    </footer>
+
+    <dialog id="export-dialog">
+      <form method="dialog">
+        <h2>Exported memories</h2>
+        <p>
+          Copy the text below into a safe place or share it with a care partner.
+        </p>
+        <textarea id="export-output" rows="12" readonly></textarea>
+        <div class="dialog-actions">
+          <button value="close" class="secondary">Close</button>
+        </div>
+      </form>
+    </dialog>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,243 @@
+const storageKey = "memory-companion-events";
+
+const selectors = {
+  form: document.querySelector("#event-form"),
+  reset: document.querySelector("#reset-form"),
+  date: document.querySelector("#event-date"),
+  time: document.querySelector("#event-time"),
+  title: document.querySelector("#event-title"),
+  details: document.querySelector("#event-details"),
+  historyList: document.querySelector("#history-list"),
+  template: document.querySelector("#event-template"),
+  filterDate: document.querySelector("#filter-date"),
+  searchText: document.querySelector("#search-text"),
+  exportButton: document.querySelector("#export-events"),
+  exportDialog: document.querySelector("#export-dialog"),
+  exportOutput: document.querySelector("#export-output"),
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  selectors.date.value = today();
+  selectors.filterDate.value = today();
+  renderHistory();
+});
+
+selectors.form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const memory = getFormData();
+
+  if (!memory.title.trim()) {
+    selectors.title.focus();
+    return;
+  }
+
+  const events = loadEvents();
+  events.push(memory);
+  saveEvents(events);
+
+  renderHistory(memory.date);
+  selectors.form.reset();
+  selectors.date.value = memory.date;
+  selectors.filterDate.value = memory.date;
+  selectors.title.focus();
+});
+
+selectors.reset.addEventListener("click", () => {
+  selectors.form.reset();
+  selectors.date.value = today();
+  selectors.title.focus();
+});
+
+selectors.filterDate.addEventListener("change", () => {
+  renderHistory(selectors.filterDate.value);
+});
+
+selectors.searchText.addEventListener("input", () => {
+  renderHistory(selectors.filterDate.value);
+});
+
+selectors.exportButton.addEventListener("click", () => {
+  const events = loadEvents();
+  if (!events.length) {
+    selectors.exportOutput.value = "No memories saved yet.";
+  } else {
+    selectors.exportOutput.value = JSON.stringify(events, null, 2);
+  }
+  selectors.exportDialog.showModal();
+});
+
+selectors.exportDialog.addEventListener("close", () => {
+  selectors.exportOutput.value = "";
+});
+
+function getFormData() {
+  const id = makeId();
+  return {
+    id,
+    date: selectors.date.value || today(),
+    time: selectors.time.value,
+    title: selectors.title.value.trim(),
+    details: selectors.details.value.trim(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function loadEvents() {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    return data;
+  } catch (error) {
+    console.error("Unable to load events", error);
+    return [];
+  }
+}
+
+function saveEvents(events) {
+  localStorage.setItem(storageKey, JSON.stringify(events));
+}
+
+function renderHistory(activeDate = today()) {
+  const events = loadEvents();
+  const searchTerm = selectors.searchText.value.trim().toLowerCase();
+  const filtered = events
+    .filter((event) => {
+      if (searchTerm) {
+        const text = `${event.title} ${event.details}`.toLowerCase();
+        return text.includes(searchTerm);
+      }
+      return true;
+    })
+    .sort((a, b) => (a.date === b.date ? compareTime(a.time, b.time) : b.date.localeCompare(a.date)));
+
+  const grouped = groupByDate(filtered);
+  selectors.historyList.innerHTML = "";
+
+  if (!grouped.length) {
+    selectors.historyList.appendChild(renderEmptyState(Boolean(searchTerm)));
+    return;
+  }
+
+  grouped.forEach(({ date, items }) => {
+    const groupElement = document.createElement("section");
+    groupElement.className = "day-group";
+
+    const header = document.createElement("header");
+    header.className = "day-group__header";
+
+    const title = document.createElement("div");
+    title.className = "day-group__title";
+    title.textContent = readableDate(date);
+    if (date === activeDate) {
+      const badge = document.createElement("span");
+      badge.textContent = "Today";
+      badge.className = "badge";
+      title.append(" ");
+      title.appendChild(badge);
+    }
+
+    const count = document.createElement("span");
+    count.className = "day-group__count";
+    count.textContent = `${items.length} ${items.length === 1 ? "memory" : "memories"}`;
+
+    header.appendChild(title);
+    header.appendChild(count);
+
+    groupElement.appendChild(header);
+
+    items.forEach((memory) => {
+      const node = renderEvent(memory);
+      groupElement.appendChild(node);
+    });
+
+    selectors.historyList.appendChild(groupElement);
+  });
+}
+
+function groupByDate(events) {
+  const map = new Map();
+  events.forEach((event) => {
+    const list = map.get(event.date) || [];
+    list.push(event);
+    map.set(event.date, list);
+  });
+
+  return Array.from(map.entries())
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .map(([date, items]) => ({
+      date,
+      items: items.sort((first, second) => compareTime(first.time, second.time)),
+    }));
+}
+
+function renderEvent(memory) {
+  const fragment = selectors.template.content.cloneNode(true);
+  const card = fragment.querySelector(".event-card");
+  const title = fragment.querySelector(".event-title");
+  const time = fragment.querySelector(".event-time");
+  const details = fragment.querySelector(".event-details");
+
+  title.textContent = memory.title;
+  time.textContent = memory.time ? formatTime(memory.time) : "Time unknown";
+  details.textContent = memory.details || "";
+
+  card.setAttribute("data-id", memory.id);
+
+  return fragment;
+}
+
+function renderEmptyState(hasSearch) {
+  const container = document.createElement("div");
+  container.className = "empty-state";
+  container.innerHTML = hasSearch
+    ? `<strong>No matches found.</strong>Try searching with different words or clearing the search box.`
+    : `<strong>No memories yet.</strong>Add your first memory using the form on the left.`;
+  return container;
+}
+
+function formatTime(value) {
+  if (!value) return "";
+  const [hour, minute] = value.split(":").map(Number);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return value;
+  const date = new Date();
+  date.setHours(hour);
+  date.setMinutes(minute);
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function compareTime(first, second) {
+  if (!first && !second) return 0;
+  if (!first) return 1;
+  if (!second) return -1;
+  return first.localeCompare(second);
+}
+
+function makeId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `memory-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function readableDate(value) {
+  if (!value) return "Unknown date";
+  const [year, month, day] = value.split("-").map(Number);
+  if ([year, month, day].some((num) => Number.isNaN(num))) return value;
+  const date = new Date(year, month - 1, day);
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date);
+}
+
+function today() {
+  const now = new Date();
+  return now.toISOString().slice(0, 10);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  --surface: #ffffff;
+  --background: #f3f6fb;
+  --primary: #255cc7;
+  --primary-dark: #1d4aa0;
+  --text: #1b1b1b;
+  --muted: #516079;
+  --border: #d4deef;
+  --radius: 14px;
+  --shadow: 0 14px 30px rgba(37, 92, 199, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  text-align: center;
+  padding: 2.5rem 1.5rem 1rem;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  max-width: 48rem;
+  margin: 0 auto;
+  color: var(--muted);
+}
+
+main {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  main {
+    grid-template-columns: 1fr 1.2fr;
+    align-items: start;
+  }
+}
+
+.form-card,
+.history-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.form-card h2,
+.history-card h2 {
+  margin-top: 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+label {
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  padding: 0.7rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #fdfefe;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 92, 199, 0.2);
+}
+
+textarea {
+  resize: vertical;
+}
+
+button {
+  border-radius: 999px;
+  border: none;
+  padding: 0.7rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+button[type="submit"],
+button.primary {
+  background: linear-gradient(135deg, var(--primary), #5a88f0);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 10px 25px rgba(37, 92, 199, 0.2);
+}
+
+button.secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(37, 92, 199, 0.3);
+  outline-offset: 2px;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.controls__label {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.controls input {
+  width: 180px;
+}
+
+.history-header {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 720px) {
+  .history-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.history-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.day-group {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f8faff;
+}
+
+.day-group__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.day-group__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.day-group__count {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 92, 199, 0.15);
+  color: var(--primary-dark);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.event-card {
+  background: white;
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  margin-top: 0.7rem;
+  border: 1px solid rgba(37, 92, 199, 0.1);
+  box-shadow: 0 6px 16px rgba(37, 92, 199, 0.08);
+}
+
+.event-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.event-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.event-time {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.event-details {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--muted);
+}
+
+.empty-state strong {
+  display: block;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+footer {
+  margin-top: auto;
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--muted);
+}
+
+#export-dialog {
+  width: min(520px, 90%);
+  border: none;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+#export-dialog::backdrop {
+  background: rgba(27, 33, 45, 0.45);
+}
+
+#export-output {
+  width: 100%;
+  margin: 1rem 0;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #f8faff;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.85rem;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page "Memory Companion" app for logging and revisiting daily events
- persist memories in browser storage with search, date filtering, and JSON export
- style the interface for clarity and gentle guidance aimed at memory support

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d040675488832f96f74b0229d3ee27