### PR TITLE
Add sign in flow and memory deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Memory-App
+# Memory Companion
+
+Memory Companion is a lightweight journal designed to help people with memory
+loss capture daily events and revisit them whenever they need a reminder. The
+app runs entirely in the browser and keeps entries stored locally so they are
+always within reach.
+
+## Features
+
+- Capture key information for each memory: date, time, title and details.
+- Quickly jump to any day with the date picker or search for keywords across
+  all entries.
+- Entries are stored in the browser via `localStorage`, meaning they remain
+  available even after the page is closed.
+- Sign in with a simple passcode so every person's memories stay private to them.
+- Export the full list of memories as JSON to share with care partners or back
+  up your data.
+- Remove individual memories when they are no longer needed.
+
+## Getting started
+
+Open `index.html` in any modern browser. No build steps or external services
+are required.
+
+For the best experience, add new memories shortly after they happen and review
+previous days in the evening.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Memory Companion</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="auth-bar" aria-live="polite">
+        <span id="auth-status-name">Not signed in</span>
+        <button type="button" id="auth-button" class="secondary">Sign in</button>
+      </div>
+      <h1>Memory Companion</h1>
+      <p class="tagline">
+        Capture your daily moments so you can revisit them whenever you need a
+        gentle reminder.
+      </p>
+    </header>
+
+    <main>
+      <section class="form-card" aria-labelledby="add-event-title">
+        <h2 id="add-event-title">Add a new memory</h2>
+        <form id="event-form">
+          <div class="form-group">
+            <label for="event-date">Date</label>
+            <input type="date" id="event-date" name="eventDate" required />
+          </div>
+          <div class="form-group">
+            <label for="event-time">Time</label>
+            <input type="time" id="event-time" name="eventTime" />
+          </div>
+          <div class="form-group">
+            <label for="event-title">Title</label>
+            <input
+              type="text"
+              id="event-title"
+              name="eventTitle"
+              placeholder="Breakfast with Alex"
+              maxlength="80"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="event-details">Details</label>
+            <textarea
+              id="event-details"
+              name="eventDetails"
+              rows="4"
+              placeholder="We met at the park and talked about the weekend plans."
+            ></textarea>
+          </div>
+          <div class="form-actions">
+            <button type="submit">Save memory</button>
+            <button type="button" id="reset-form" class="secondary">
+              Clear
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="history-card" aria-labelledby="history-title">
+        <div class="history-header">
+          <div>
+            <h2 id="history-title">Memory history</h2>
+            <p class="history-subtitle">
+              Select a date to revisit what happened.
+            </p>
+          </div>
+          <div class="controls">
+            <label class="controls__label" for="filter-date">Go to date</label>
+            <input type="date" id="filter-date" />
+            <label class="controls__label" for="search-text">Search</label>
+            <input
+              type="search"
+              id="search-text"
+              placeholder="Type a word like 'doctor'"
+              aria-label="Search memories"
+            />
+            <button type="button" id="export-events" class="secondary">
+              Export
+            </button>
+          </div>
+        </div>
+        <div id="history-list" class="history-list" aria-live="polite"></div>
+        <template id="event-template">
+          <article class="event-card">
+            <header>
+              <div class="event-header-text">
+                <h3 class="event-title"></h3>
+                <time class="event-time"></time>
+              </div>
+              <button
+                type="button"
+                class="event-delete"
+                aria-label="Delete this memory"
+              >
+                Delete
+              </button>
+            </header>
+            <p class="event-details"></p>
+          </article>
+        </template>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Tip: try adding memories as soon as they happen. Reviewing them each
+        evening can reinforce your day.
+      </p>
+    </footer>
+
+    <dialog id="export-dialog">
+      <form method="dialog">
+        <h2>Exported memories</h2>
+        <p>
+          Copy the text below into a safe place or share it with a care partner.
+        </p>
+        <textarea id="export-output" rows="12" readonly></textarea>
+        <div class="dialog-actions">
+          <button value="close" class="secondary">Close</button>
+        </div>
+      </form>
+    </dialog>
+
+    <dialog id="auth-dialog">
+      <form id="auth-form">
+        <h2 id="auth-dialog-title">Sign in</h2>
+        <p id="auth-dialog-description">
+          Enter your name and passcode to continue.
+        </p>
+        <div class="form-group">
+          <label for="auth-name">Name</label>
+          <input
+            type="text"
+            id="auth-name"
+            name="authName"
+            autocomplete="name"
+            maxlength="60"
+            required
+          />
+        </div>
+        <div class="form-group">
+          <label for="auth-pin">Passcode</label>
+          <input
+            type="password"
+            id="auth-pin"
+            name="authPin"
+            inputmode="numeric"
+            minlength="4"
+            maxlength="12"
+            required
+          />
+        </div>
+        <div class="form-group" id="auth-confirm-group" hidden>
+          <label for="auth-confirm-pin">Confirm passcode</label>
+          <input
+            type="password"
+            id="auth-confirm-pin"
+            name="authConfirmPin"
+            minlength="4"
+            maxlength="12"
+          />
+        </div>
+        <p id="auth-message" role="alert" hidden></p>
+        <div class="auth-actions">
+          <button type="submit" id="auth-submit">Sign in</button>
+          <button type="button" id="auth-mode-toggle" class="secondary">
+            Need an account? Create one
+          </button>
+          <button type="button" id="auth-cancel" class="secondary">
+            Cancel
+          </button>
+        </div>
+      </form>
+    </dialog>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
-const storageKeyBase = "memory-companion-events";
-const accountsKey = "memory-companion-users";
-const activeUserKey = "memory-companion-active-user";
+const STORAGE_PREFIX = "memory-companion";
+const ACCOUNTS_KEY = `${STORAGE_PREFIX}-accounts`;
+const SESSION_KEY = `${STORAGE_PREFIX}-active-user`;
 
 const selectors = {
   form: document.querySelector("#event-form"),
@@ -32,29 +32,34 @@ const selectors = {
   authMessage: document.querySelector("#auth-message"),
 };
 
-let currentUser = null;
-let authMode = "signin";
+const state = {
+  user: null,
+  authMode: "signin",
+};
 
 document.addEventListener("DOMContentLoaded", () => {
-  selectors.date.value = today();
-  selectors.filterDate.value = today();
-  restoreActiveUser();
+  const todayValue = today();
+  selectors.date.value = todayValue;
+  selectors.filterDate.value = todayValue;
+
+  restoreSession();
   updateAuthUI();
   renderHistory();
-  if (!currentUser) {
+
+  if (!state.user) {
     openAuthDialog();
   }
 });
 
 selectors.form.addEventListener("submit", (event) => {
   event.preventDefault();
-  if (!currentUser) {
+
+  if (!state.user) {
     openAuthDialog();
     return;
   }
 
-  const memory = getFormData();
-
+  const memory = getMemoryFromForm();
   if (!memory.title.trim()) {
     selectors.title.focus();
     return;
@@ -64,11 +69,12 @@ selectors.form.addEventListener("submit", (event) => {
   events.push(memory);
   saveEvents(events);
 
-  renderHistory(memory.date);
   selectors.form.reset();
   selectors.date.value = memory.date;
   selectors.filterDate.value = memory.date;
   selectors.title.focus();
+
+  renderHistory();
 });
 
 selectors.reset.addEventListener("click", () => {
@@ -78,32 +84,30 @@ selectors.reset.addEventListener("click", () => {
 });
 
 selectors.filterDate.addEventListener("change", () => {
-  if (!currentUser) {
+  if (!state.user) {
     openAuthDialog();
     return;
   }
-  renderHistory(selectors.filterDate.value);
+  renderHistory();
 });
 
 selectors.searchText.addEventListener("input", () => {
-  if (!currentUser) {
+  if (!state.user) {
     return;
   }
-  renderHistory(selectors.filterDate.value);
+  renderHistory();
 });
 
 selectors.exportButton.addEventListener("click", () => {
-  if (!currentUser) {
+  if (!state.user) {
     openAuthDialog();
     return;
   }
 
   const events = loadEvents();
-  if (!events.length) {
-    selectors.exportOutput.value = "No memories saved yet.";
-  } else {
-    selectors.exportOutput.value = JSON.stringify(events, null, 2);
-  }
+  selectors.exportOutput.value = events.length
+    ? JSON.stringify(events, null, 2)
+    : "No memories saved yet.";
   selectors.exportDialog.showModal();
 });
 
@@ -113,23 +117,27 @@ selectors.exportDialog.addEventListener("close", () => {
 
 selectors.historyList.addEventListener("click", (event) => {
   const button = event.target.closest(".event-delete");
-  if (!button || !currentUser) {
+  if (!button || !state.user) {
     return;
   }
 
   const card = button.closest(".event-card");
-  const id = card?.getAttribute("data-id");
-  if (!id) return;
+  const id = card?.dataset.id;
+  if (!id) {
+    return;
+  }
 
-  const confirmation = window.confirm("Delete this memory? This action cannot be undone.");
-  if (!confirmation) return;
+  const confirmed = window.confirm("Delete this memory? This cannot be undone.");
+  if (!confirmed) {
+    return;
+  }
 
   deleteMemory(id);
-  renderHistory(selectors.filterDate.value);
+  renderHistory();
 });
 
 selectors.authButton.addEventListener("click", () => {
-  if (currentUser) {
+  if (state.user) {
     signOut();
   } else {
     openAuthDialog();
@@ -137,7 +145,7 @@ selectors.authButton.addEventListener("click", () => {
 });
 
 selectors.authModeToggle.addEventListener("click", () => {
-  const nextMode = authMode === "signin" ? "create" : "signin";
+  const nextMode = state.authMode === "signin" ? "create" : "signin";
   setAuthMode(nextMode);
   selectors.authForm.reset();
   showAuthMessage("");
@@ -154,8 +162,12 @@ selectors.authDialog.addEventListener("close", () => {
   setAuthMode("signin");
 });
 
-selectors.authForm.addEventListener("submit", async (event) => {
+selectors.authForm.addEventListener("submit", (event) => {
   event.preventDefault();
+  handleAuthSubmit();
+});
+
+async function handleAuthSubmit() {
   const name = selectors.authName.value.trim();
   const pin = selectors.authPin.value.trim();
 
@@ -164,7 +176,7 @@ selectors.authForm.addEventListener("submit", async (event) => {
     return;
   }
 
-  if (authMode === "create") {
+  if (state.authMode === "create") {
     const confirmPin = selectors.authConfirmPin.value.trim();
     if (!confirmPin) {
       showAuthMessage("Please confirm your passcode.");
@@ -180,12 +192,11 @@ selectors.authForm.addEventListener("submit", async (event) => {
   } else {
     await signIn(name, pin);
   }
-});
+}
 
-function getFormData() {
-  const id = makeId("memory");
+function getMemoryFromForm() {
   return {
-    id,
+    id: makeId("memory"),
     date: selectors.date.value || today(),
     time: selectors.time.value,
     title: selectors.title.value.trim(),
@@ -195,62 +206,81 @@ function getFormData() {
 }
 
 function loadEvents() {
-  if (!currentUser) return [];
-  const storageKey = `${storageKeyBase}-${currentUser.id}`;
+  if (!state.user) {
+    return [];
+  }
+
+  const storageKey = `${STORAGE_PREFIX}-events-${state.user.id}`;
   try {
     const raw = localStorage.getItem(storageKey);
-    if (!raw) return [];
+    if (!raw) {
+      return [];
+    }
     const data = JSON.parse(raw);
-    if (!Array.isArray(data)) return [];
-    return data;
+    return Array.isArray(data) ? data : [];
   } catch (error) {
-    console.error("Unable to load events", error);
+    console.error("Unable to load memories", error);
     return [];
   }
 }
 
 function saveEvents(events) {
-  if (!currentUser) return;
-  const storageKey = `${storageKeyBase}-${currentUser.id}`;
+  if (!state.user) {
+    return;
+  }
+
+  const storageKey = `${STORAGE_PREFIX}-events-${state.user.id}`;
   localStorage.setItem(storageKey, JSON.stringify(events));
 }
 
 function deleteMemory(id) {
   const events = loadEvents();
-  const updated = events.filter((event) => event.id !== id);
-  saveEvents(updated);
+  const next = events.filter((event) => event.id !== id);
+  saveEvents(next);
 }
 
-function renderHistory(activeDate = today()) {
-  if (!currentUser) {
-    selectors.historyList.innerHTML = "";
+function renderHistory() {
+  selectors.historyList.innerHTML = "";
+
+  if (!state.user) {
     selectors.historyList.appendChild(renderAuthPrompt());
     return;
   }
 
   const events = loadEvents();
+  const activeDate = selectors.filterDate.value || today();
   const searchTerm = selectors.searchText.value.trim().toLowerCase();
+
   const filtered = events
     .filter((event) => {
-      if (searchTerm) {
-        const text = `${event.title} ${event.details}`.toLowerCase();
-        return text.includes(searchTerm);
+      if (!searchTerm) {
+        return true;
       }
-      return true;
+      const text = `${event.title} ${event.details}`.toLowerCase();
+      return text.includes(searchTerm);
     })
-    .sort((a, b) => (a.date === b.date ? compareTime(a.time, b.time) : b.date.localeCompare(a.date)));
+    .sort((a, b) => {
+      if (a.date === b.date) {
+        return compareTime(a.time, b.time);
+      }
+      return b.date.localeCompare(a.date);
+    });
 
   const grouped = groupByDate(filtered);
-  selectors.historyList.innerHTML = "";
 
   if (!grouped.length) {
     selectors.historyList.appendChild(renderEmptyState(Boolean(searchTerm)));
     return;
   }
 
+  const todayValue = today();
+
   grouped.forEach(({ date, items }) => {
-    const groupElement = document.createElement("section");
-    groupElement.className = "day-group";
+    const group = document.createElement("section");
+    group.className = "day-group";
+    if (date === activeDate) {
+      group.classList.add("day-group--selected");
+    }
 
     const header = document.createElement("header");
     header.className = "day-group__header";
@@ -258,10 +288,17 @@ function renderHistory(activeDate = today()) {
     const title = document.createElement("div");
     title.className = "day-group__title";
     title.textContent = readableDate(date);
-    if (date === activeDate) {
+
+    if (date === todayValue) {
       const badge = document.createElement("span");
-      badge.textContent = "Today";
       badge.className = "badge";
+      badge.textContent = "Today";
+      title.append(" ");
+      title.appendChild(badge);
+    } else if (date === activeDate) {
+      const badge = document.createElement("span");
+      badge.className = "badge badge--selected";
+      badge.textContent = "Selected day";
       title.append(" ");
       title.appendChild(badge);
     }
@@ -272,15 +309,16 @@ function renderHistory(activeDate = today()) {
 
     header.appendChild(title);
     header.appendChild(count);
+    group.appendChild(header);
 
-    groupElement.appendChild(header);
+    items
+      .sort((first, second) => compareTime(first.time, second.time))
+      .forEach((memory) => {
+        const card = renderMemory(memory);
+        group.appendChild(card);
+      });
 
-    items.forEach((memory) => {
-      const node = renderEvent(memory);
-      groupElement.appendChild(node);
-    });
-
-    selectors.historyList.appendChild(groupElement);
+    selectors.historyList.appendChild(group);
   });
 }
 
@@ -294,24 +332,20 @@ function groupByDate(events) {
 
   return Array.from(map.entries())
     .sort((a, b) => b[0].localeCompare(a[0]))
-    .map(([date, items]) => ({
-      date,
-      items: items.sort((first, second) => compareTime(first.time, second.time)),
-    }));
+    .map(([date, items]) => ({ date, items }));
 }
 
-function renderEvent(memory) {
+function renderMemory(memory) {
   const fragment = selectors.template.content.cloneNode(true);
   const card = fragment.querySelector(".event-card");
   const title = fragment.querySelector(".event-title");
   const time = fragment.querySelector(".event-time");
   const details = fragment.querySelector(".event-details");
 
+  card.dataset.id = memory.id;
   title.textContent = memory.title;
   time.textContent = memory.time ? formatTime(memory.time) : "Time unknown";
   details.textContent = memory.details || "";
-
-  card.setAttribute("data-id", memory.id);
 
   return fragment;
 }
@@ -320,35 +354,48 @@ function renderEmptyState(hasSearch) {
   const container = document.createElement("div");
   container.className = "empty-state";
   container.innerHTML = hasSearch
-    ? `<strong>No matches found.</strong>Try searching with different words or clearing the search box.`
-    : `<strong>No memories yet.</strong>Add your first memory using the form on the left.`;
+    ? `<strong>No matches found.</strong> Try searching for another word or clearing the search box.`
+    : `<strong>No memories yet.</strong> Add your first memory using the form on the left.`;
   return container;
 }
 
 function renderAuthPrompt() {
   const container = document.createElement("div");
   container.className = "empty-state";
-  container.innerHTML = `<strong>Sign in to begin.</strong>Your memories are kept safe under your own passcode.`;
+  container.innerHTML = `<strong>Sign in to begin.</strong> Your memories stay private to your profile.`;
   return container;
 }
 
 function formatTime(value) {
-  if (!value) return "";
+  if (!value) {
+    return "";
+  }
+
   const [hour, minute] = value.split(":").map(Number);
-  if (Number.isNaN(hour) || Number.isNaN(minute)) return value;
-  const date = new Date();
-  date.setHours(hour);
-  date.setMinutes(minute);
+  if ([hour, minute].some((num) => Number.isNaN(num))) {
+    return value;
+  }
+
+  const time = new Date();
+  time.setHours(hour);
+  time.setMinutes(minute);
+
   return new Intl.DateTimeFormat(undefined, {
     hour: "numeric",
     minute: "2-digit",
-  }).format(date);
+  }).format(time);
 }
 
 function compareTime(first, second) {
-  if (!first && !second) return 0;
-  if (!first) return 1;
-  if (!second) return -1;
+  if (!first && !second) {
+    return 0;
+  }
+  if (!first) {
+    return 1;
+  }
+  if (!second) {
+    return -1;
+  }
   return first.localeCompare(second);
 }
 
@@ -360,9 +407,15 @@ function makeId(prefix = "memory") {
 }
 
 function readableDate(value) {
-  if (!value) return "Unknown date";
+  if (!value) {
+    return "Unknown date";
+  }
+
   const [year, month, day] = value.split("-").map(Number);
-  if ([year, month, day].some((num) => Number.isNaN(num))) return value;
+  if ([year, month, day].some((num) => Number.isNaN(num))) {
+    return value;
+  }
+
   const date = new Date(year, month - 1, day);
   return new Intl.DateTimeFormat(undefined, {
     weekday: "long",
@@ -373,31 +426,29 @@ function readableDate(value) {
 }
 
 function today() {
-  const now = new Date();
-  return now.toISOString().slice(0, 10);
+  return new Date().toISOString().slice(0, 10);
 }
 
 function setAuthMode(mode) {
-  authMode = mode;
-  const isCreate = mode === "create";
-  selectors.authDialogTitle.textContent = isCreate ? "Create account" : "Sign in";
-  selectors.authDialogDescription.textContent = isCreate
+  state.authMode = mode;
+  const creating = mode === "create";
+  selectors.authDialogTitle.textContent = creating ? "Create account" : "Sign in";
+  selectors.authDialogDescription.textContent = creating
     ? "Create a profile so your memories stay private to you."
     : "Enter your name and passcode to continue.";
-  selectors.authSubmit.textContent = isCreate ? "Create account" : "Sign in";
-  selectors.authModeToggle.textContent = isCreate
+  selectors.authSubmit.textContent = creating ? "Create account" : "Sign in";
+  selectors.authModeToggle.textContent = creating
     ? "Already have an account? Sign in"
     : "Need an account? Create one";
-  selectors.authConfirmGroup.hidden = !isCreate;
-  selectors.authConfirmPin.required = isCreate;
+  selectors.authConfirmGroup.hidden = !creating;
+  selectors.authConfirmPin.required = creating;
 }
 
-function openAuthDialog(mode = authMode) {
-  selectors.authForm.reset();
-  showAuthMessage("");
+function openAuthDialog(mode = state.authMode) {
   setAuthMode(mode);
-  if (mode === "signin" && currentUser) {
-    selectors.authName.value = currentUser.name;
+  showAuthMessage("");
+  if (mode === "signin" && state.user) {
+    selectors.authName.value = state.user.name;
   }
   if (!selectors.authDialog.open) {
     selectors.authDialog.showModal();
@@ -411,45 +462,51 @@ function showAuthMessage(message) {
 }
 
 function updateAuthUI() {
-  if (currentUser) {
-    selectors.authStatusName.textContent = `Signed in as ${currentUser.name}`;
+  if (state.user) {
+    selectors.authStatusName.textContent = `Signed in as ${state.user.name}`;
     selectors.authButton.textContent = "Sign out";
   } else {
     selectors.authStatusName.textContent = "Not signed in";
     selectors.authButton.textContent = "Sign in";
   }
-  setFormEnabled(Boolean(currentUser));
+
+  setAppEnabled(Boolean(state.user));
 }
 
-function setFormEnabled(enabled) {
-  const elements = selectors.form.querySelectorAll("input, textarea, button");
-  elements.forEach((element) => {
-    element.disabled = !enabled;
+function setAppEnabled(enabled) {
+  const fields = selectors.form.querySelectorAll("input, textarea, button");
+  fields.forEach((field) => {
+    field.disabled = !enabled;
   });
+
   selectors.filterDate.disabled = !enabled;
   selectors.searchText.disabled = !enabled;
   selectors.exportButton.disabled = !enabled;
 }
 
-function restoreActiveUser() {
-  const activeId = localStorage.getItem(activeUserKey);
-  if (!activeId) return;
+function restoreSession() {
+  const activeId = localStorage.getItem(SESSION_KEY);
+  if (!activeId) {
+    return;
+  }
+
   const accounts = loadAccounts();
   const account = accounts.find((user) => user.id === activeId);
   if (account) {
-    currentUser = account;
+    state.user = account;
   } else {
-    localStorage.removeItem(activeUserKey);
+    localStorage.removeItem(SESSION_KEY);
   }
 }
 
 function loadAccounts() {
   try {
-    const raw = localStorage.getItem(accountsKey);
-    if (!raw) return [];
+    const raw = localStorage.getItem(ACCOUNTS_KEY);
+    if (!raw) {
+      return [];
+    }
     const data = JSON.parse(raw);
-    if (!Array.isArray(data)) return [];
-    return data;
+    return Array.isArray(data) ? data : [];
   } catch (error) {
     console.error("Unable to load accounts", error);
     return [];
@@ -457,21 +514,22 @@ function loadAccounts() {
 }
 
 function saveAccounts(accounts) {
-  localStorage.setItem(accountsKey, JSON.stringify(accounts));
+  localStorage.setItem(ACCOUNTS_KEY, JSON.stringify(accounts));
 }
 
 async function createAccount(name, pin) {
   const accounts = loadAccounts();
   const exists = accounts.some((account) => account.name.toLowerCase() === name.toLowerCase());
+
   if (exists) {
-    showAuthMessage("That name is already in use. Try a different one or sign in.");
+    showAuthMessage("That name is already in use. Try another or sign in.");
     return;
   }
 
   const account = {
     id: makeId("user"),
     name,
-    pinHash: await hashString(pin),
+    pinHash: await hashPasscode(pin),
     createdAt: new Date().toISOString(),
   };
 
@@ -490,7 +548,7 @@ async function signIn(name, pin) {
     return;
   }
 
-  const hash = await hashString(pin);
+  const hash = await hashPasscode(pin);
   if (hash !== account.pinHash) {
     showAuthMessage("Incorrect passcode. Please try again.");
     return;
@@ -501,19 +559,19 @@ async function signIn(name, pin) {
 }
 
 function activateUser(account) {
-  currentUser = account;
-  localStorage.setItem(activeUserKey, account.id);
-  updateAuthUI();
+  state.user = account;
+  localStorage.setItem(SESSION_KEY, account.id);
   selectors.form.reset();
   selectors.date.value = today();
   selectors.filterDate.value = today();
   selectors.searchText.value = "";
+  updateAuthUI();
   renderHistory();
 }
 
 function signOut() {
-  currentUser = null;
-  localStorage.removeItem(activeUserKey);
+  state.user = null;
+  localStorage.removeItem(SESSION_KEY);
   selectors.form.reset();
   selectors.date.value = today();
   selectors.filterDate.value = today();
@@ -523,7 +581,7 @@ function signOut() {
   openAuthDialog();
 }
 
-async function hashString(value) {
+async function hashPasscode(value) {
   if (typeof crypto !== "undefined" && crypto.subtle && crypto.subtle.digest) {
     const encoder = new TextEncoder();
     const data = encoder.encode(value);
@@ -532,5 +590,6 @@ async function hashString(value) {
       .map((byte) => byte.toString(16).padStart(2, "0"))
       .join("");
   }
+
   return value;
 }

--- a/script.js
+++ b/script.js
@@ -1,0 +1,536 @@
+const storageKeyBase = "memory-companion-events";
+const accountsKey = "memory-companion-users";
+const activeUserKey = "memory-companion-active-user";
+
+const selectors = {
+  form: document.querySelector("#event-form"),
+  reset: document.querySelector("#reset-form"),
+  date: document.querySelector("#event-date"),
+  time: document.querySelector("#event-time"),
+  title: document.querySelector("#event-title"),
+  details: document.querySelector("#event-details"),
+  historyList: document.querySelector("#history-list"),
+  template: document.querySelector("#event-template"),
+  filterDate: document.querySelector("#filter-date"),
+  searchText: document.querySelector("#search-text"),
+  exportButton: document.querySelector("#export-events"),
+  exportDialog: document.querySelector("#export-dialog"),
+  exportOutput: document.querySelector("#export-output"),
+  authStatusName: document.querySelector("#auth-status-name"),
+  authButton: document.querySelector("#auth-button"),
+  authDialog: document.querySelector("#auth-dialog"),
+  authForm: document.querySelector("#auth-form"),
+  authDialogTitle: document.querySelector("#auth-dialog-title"),
+  authDialogDescription: document.querySelector("#auth-dialog-description"),
+  authSubmit: document.querySelector("#auth-submit"),
+  authModeToggle: document.querySelector("#auth-mode-toggle"),
+  authCancel: document.querySelector("#auth-cancel"),
+  authConfirmGroup: document.querySelector("#auth-confirm-group"),
+  authName: document.querySelector("#auth-name"),
+  authPin: document.querySelector("#auth-pin"),
+  authConfirmPin: document.querySelector("#auth-confirm-pin"),
+  authMessage: document.querySelector("#auth-message"),
+};
+
+let currentUser = null;
+let authMode = "signin";
+
+document.addEventListener("DOMContentLoaded", () => {
+  selectors.date.value = today();
+  selectors.filterDate.value = today();
+  restoreActiveUser();
+  updateAuthUI();
+  renderHistory();
+  if (!currentUser) {
+    openAuthDialog();
+  }
+});
+
+selectors.form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  if (!currentUser) {
+    openAuthDialog();
+    return;
+  }
+
+  const memory = getFormData();
+
+  if (!memory.title.trim()) {
+    selectors.title.focus();
+    return;
+  }
+
+  const events = loadEvents();
+  events.push(memory);
+  saveEvents(events);
+
+  renderHistory(memory.date);
+  selectors.form.reset();
+  selectors.date.value = memory.date;
+  selectors.filterDate.value = memory.date;
+  selectors.title.focus();
+});
+
+selectors.reset.addEventListener("click", () => {
+  selectors.form.reset();
+  selectors.date.value = today();
+  selectors.title.focus();
+});
+
+selectors.filterDate.addEventListener("change", () => {
+  if (!currentUser) {
+    openAuthDialog();
+    return;
+  }
+  renderHistory(selectors.filterDate.value);
+});
+
+selectors.searchText.addEventListener("input", () => {
+  if (!currentUser) {
+    return;
+  }
+  renderHistory(selectors.filterDate.value);
+});
+
+selectors.exportButton.addEventListener("click", () => {
+  if (!currentUser) {
+    openAuthDialog();
+    return;
+  }
+
+  const events = loadEvents();
+  if (!events.length) {
+    selectors.exportOutput.value = "No memories saved yet.";
+  } else {
+    selectors.exportOutput.value = JSON.stringify(events, null, 2);
+  }
+  selectors.exportDialog.showModal();
+});
+
+selectors.exportDialog.addEventListener("close", () => {
+  selectors.exportOutput.value = "";
+});
+
+selectors.historyList.addEventListener("click", (event) => {
+  const button = event.target.closest(".event-delete");
+  if (!button || !currentUser) {
+    return;
+  }
+
+  const card = button.closest(".event-card");
+  const id = card?.getAttribute("data-id");
+  if (!id) return;
+
+  const confirmation = window.confirm("Delete this memory? This action cannot be undone.");
+  if (!confirmation) return;
+
+  deleteMemory(id);
+  renderHistory(selectors.filterDate.value);
+});
+
+selectors.authButton.addEventListener("click", () => {
+  if (currentUser) {
+    signOut();
+  } else {
+    openAuthDialog();
+  }
+});
+
+selectors.authModeToggle.addEventListener("click", () => {
+  const nextMode = authMode === "signin" ? "create" : "signin";
+  setAuthMode(nextMode);
+  selectors.authForm.reset();
+  showAuthMessage("");
+  selectors.authName.focus();
+});
+
+selectors.authCancel.addEventListener("click", () => {
+  selectors.authDialog.close();
+});
+
+selectors.authDialog.addEventListener("close", () => {
+  selectors.authForm.reset();
+  showAuthMessage("");
+  setAuthMode("signin");
+});
+
+selectors.authForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const name = selectors.authName.value.trim();
+  const pin = selectors.authPin.value.trim();
+
+  if (!name || !pin) {
+    showAuthMessage("Please enter your name and passcode.");
+    return;
+  }
+
+  if (authMode === "create") {
+    const confirmPin = selectors.authConfirmPin.value.trim();
+    if (!confirmPin) {
+      showAuthMessage("Please confirm your passcode.");
+      return;
+    }
+
+    if (pin !== confirmPin) {
+      showAuthMessage("Passcodes do not match. Try again.");
+      return;
+    }
+
+    await createAccount(name, pin);
+  } else {
+    await signIn(name, pin);
+  }
+});
+
+function getFormData() {
+  const id = makeId("memory");
+  return {
+    id,
+    date: selectors.date.value || today(),
+    time: selectors.time.value,
+    title: selectors.title.value.trim(),
+    details: selectors.details.value.trim(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function loadEvents() {
+  if (!currentUser) return [];
+  const storageKey = `${storageKeyBase}-${currentUser.id}`;
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    return data;
+  } catch (error) {
+    console.error("Unable to load events", error);
+    return [];
+  }
+}
+
+function saveEvents(events) {
+  if (!currentUser) return;
+  const storageKey = `${storageKeyBase}-${currentUser.id}`;
+  localStorage.setItem(storageKey, JSON.stringify(events));
+}
+
+function deleteMemory(id) {
+  const events = loadEvents();
+  const updated = events.filter((event) => event.id !== id);
+  saveEvents(updated);
+}
+
+function renderHistory(activeDate = today()) {
+  if (!currentUser) {
+    selectors.historyList.innerHTML = "";
+    selectors.historyList.appendChild(renderAuthPrompt());
+    return;
+  }
+
+  const events = loadEvents();
+  const searchTerm = selectors.searchText.value.trim().toLowerCase();
+  const filtered = events
+    .filter((event) => {
+      if (searchTerm) {
+        const text = `${event.title} ${event.details}`.toLowerCase();
+        return text.includes(searchTerm);
+      }
+      return true;
+    })
+    .sort((a, b) => (a.date === b.date ? compareTime(a.time, b.time) : b.date.localeCompare(a.date)));
+
+  const grouped = groupByDate(filtered);
+  selectors.historyList.innerHTML = "";
+
+  if (!grouped.length) {
+    selectors.historyList.appendChild(renderEmptyState(Boolean(searchTerm)));
+    return;
+  }
+
+  grouped.forEach(({ date, items }) => {
+    const groupElement = document.createElement("section");
+    groupElement.className = "day-group";
+
+    const header = document.createElement("header");
+    header.className = "day-group__header";
+
+    const title = document.createElement("div");
+    title.className = "day-group__title";
+    title.textContent = readableDate(date);
+    if (date === activeDate) {
+      const badge = document.createElement("span");
+      badge.textContent = "Today";
+      badge.className = "badge";
+      title.append(" ");
+      title.appendChild(badge);
+    }
+
+    const count = document.createElement("span");
+    count.className = "day-group__count";
+    count.textContent = `${items.length} ${items.length === 1 ? "memory" : "memories"}`;
+
+    header.appendChild(title);
+    header.appendChild(count);
+
+    groupElement.appendChild(header);
+
+    items.forEach((memory) => {
+      const node = renderEvent(memory);
+      groupElement.appendChild(node);
+    });
+
+    selectors.historyList.appendChild(groupElement);
+  });
+}
+
+function groupByDate(events) {
+  const map = new Map();
+  events.forEach((event) => {
+    const list = map.get(event.date) || [];
+    list.push(event);
+    map.set(event.date, list);
+  });
+
+  return Array.from(map.entries())
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .map(([date, items]) => ({
+      date,
+      items: items.sort((first, second) => compareTime(first.time, second.time)),
+    }));
+}
+
+function renderEvent(memory) {
+  const fragment = selectors.template.content.cloneNode(true);
+  const card = fragment.querySelector(".event-card");
+  const title = fragment.querySelector(".event-title");
+  const time = fragment.querySelector(".event-time");
+  const details = fragment.querySelector(".event-details");
+
+  title.textContent = memory.title;
+  time.textContent = memory.time ? formatTime(memory.time) : "Time unknown";
+  details.textContent = memory.details || "";
+
+  card.setAttribute("data-id", memory.id);
+
+  return fragment;
+}
+
+function renderEmptyState(hasSearch) {
+  const container = document.createElement("div");
+  container.className = "empty-state";
+  container.innerHTML = hasSearch
+    ? `<strong>No matches found.</strong>Try searching with different words or clearing the search box.`
+    : `<strong>No memories yet.</strong>Add your first memory using the form on the left.`;
+  return container;
+}
+
+function renderAuthPrompt() {
+  const container = document.createElement("div");
+  container.className = "empty-state";
+  container.innerHTML = `<strong>Sign in to begin.</strong>Your memories are kept safe under your own passcode.`;
+  return container;
+}
+
+function formatTime(value) {
+  if (!value) return "";
+  const [hour, minute] = value.split(":").map(Number);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return value;
+  const date = new Date();
+  date.setHours(hour);
+  date.setMinutes(minute);
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function compareTime(first, second) {
+  if (!first && !second) return 0;
+  if (!first) return 1;
+  if (!second) return -1;
+  return first.localeCompare(second);
+}
+
+function makeId(prefix = "memory") {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function readableDate(value) {
+  if (!value) return "Unknown date";
+  const [year, month, day] = value.split("-").map(Number);
+  if ([year, month, day].some((num) => Number.isNaN(num))) return value;
+  const date = new Date(year, month - 1, day);
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date);
+}
+
+function today() {
+  const now = new Date();
+  return now.toISOString().slice(0, 10);
+}
+
+function setAuthMode(mode) {
+  authMode = mode;
+  const isCreate = mode === "create";
+  selectors.authDialogTitle.textContent = isCreate ? "Create account" : "Sign in";
+  selectors.authDialogDescription.textContent = isCreate
+    ? "Create a profile so your memories stay private to you."
+    : "Enter your name and passcode to continue.";
+  selectors.authSubmit.textContent = isCreate ? "Create account" : "Sign in";
+  selectors.authModeToggle.textContent = isCreate
+    ? "Already have an account? Sign in"
+    : "Need an account? Create one";
+  selectors.authConfirmGroup.hidden = !isCreate;
+  selectors.authConfirmPin.required = isCreate;
+}
+
+function openAuthDialog(mode = authMode) {
+  selectors.authForm.reset();
+  showAuthMessage("");
+  setAuthMode(mode);
+  if (mode === "signin" && currentUser) {
+    selectors.authName.value = currentUser.name;
+  }
+  if (!selectors.authDialog.open) {
+    selectors.authDialog.showModal();
+  }
+  selectors.authName.focus();
+}
+
+function showAuthMessage(message) {
+  selectors.authMessage.textContent = message;
+  selectors.authMessage.hidden = !message;
+}
+
+function updateAuthUI() {
+  if (currentUser) {
+    selectors.authStatusName.textContent = `Signed in as ${currentUser.name}`;
+    selectors.authButton.textContent = "Sign out";
+  } else {
+    selectors.authStatusName.textContent = "Not signed in";
+    selectors.authButton.textContent = "Sign in";
+  }
+  setFormEnabled(Boolean(currentUser));
+}
+
+function setFormEnabled(enabled) {
+  const elements = selectors.form.querySelectorAll("input, textarea, button");
+  elements.forEach((element) => {
+    element.disabled = !enabled;
+  });
+  selectors.filterDate.disabled = !enabled;
+  selectors.searchText.disabled = !enabled;
+  selectors.exportButton.disabled = !enabled;
+}
+
+function restoreActiveUser() {
+  const activeId = localStorage.getItem(activeUserKey);
+  if (!activeId) return;
+  const accounts = loadAccounts();
+  const account = accounts.find((user) => user.id === activeId);
+  if (account) {
+    currentUser = account;
+  } else {
+    localStorage.removeItem(activeUserKey);
+  }
+}
+
+function loadAccounts() {
+  try {
+    const raw = localStorage.getItem(accountsKey);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    return data;
+  } catch (error) {
+    console.error("Unable to load accounts", error);
+    return [];
+  }
+}
+
+function saveAccounts(accounts) {
+  localStorage.setItem(accountsKey, JSON.stringify(accounts));
+}
+
+async function createAccount(name, pin) {
+  const accounts = loadAccounts();
+  const exists = accounts.some((account) => account.name.toLowerCase() === name.toLowerCase());
+  if (exists) {
+    showAuthMessage("That name is already in use. Try a different one or sign in.");
+    return;
+  }
+
+  const account = {
+    id: makeId("user"),
+    name,
+    pinHash: await hashString(pin),
+    createdAt: new Date().toISOString(),
+  };
+
+  accounts.push(account);
+  saveAccounts(accounts);
+  activateUser(account);
+  selectors.authDialog.close();
+}
+
+async function signIn(name, pin) {
+  const accounts = loadAccounts();
+  const account = accounts.find((user) => user.name.toLowerCase() === name.toLowerCase());
+
+  if (!account) {
+    showAuthMessage("We couldn't find that name. Try again or create an account.");
+    return;
+  }
+
+  const hash = await hashString(pin);
+  if (hash !== account.pinHash) {
+    showAuthMessage("Incorrect passcode. Please try again.");
+    return;
+  }
+
+  activateUser(account);
+  selectors.authDialog.close();
+}
+
+function activateUser(account) {
+  currentUser = account;
+  localStorage.setItem(activeUserKey, account.id);
+  updateAuthUI();
+  selectors.form.reset();
+  selectors.date.value = today();
+  selectors.filterDate.value = today();
+  selectors.searchText.value = "";
+  renderHistory();
+}
+
+function signOut() {
+  currentUser = null;
+  localStorage.removeItem(activeUserKey);
+  selectors.form.reset();
+  selectors.date.value = today();
+  selectors.filterDate.value = today();
+  selectors.searchText.value = "";
+  updateAuthUI();
+  renderHistory();
+  openAuthDialog();
+}
+
+async function hashString(value) {
+  if (typeof crypto !== "undefined" && crypto.subtle && crypto.subtle.digest) {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(value);
+    const digest = await crypto.subtle.digest("SHA-256", data);
+    return Array.from(new Uint8Array(digest))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+  }
+  return value;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,375 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  --surface: #ffffff;
+  --background: #f3f6fb;
+  --primary: #255cc7;
+  --primary-dark: #1d4aa0;
+  --text: #1b1b1b;
+  --muted: #516079;
+  --border: #d4deef;
+  --radius: 14px;
+  --shadow: 0 14px 30px rgba(37, 92, 199, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+
+.auth-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+.auth-bar button {
+  padding: 0.5rem 1.1rem;
+}
+.app-header {
+  text-align: center;
+  padding: 2.5rem 1.5rem 1rem;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  max-width: 48rem;
+  margin: 0 auto;
+  color: var(--muted);
+}
+
+main {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  main {
+    grid-template-columns: 1fr 1.2fr;
+    align-items: start;
+  }
+}
+
+.form-card,
+.history-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.form-card h2,
+.history-card h2 {
+  margin-top: 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+label {
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  padding: 0.7rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #fdfefe;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 92, 199, 0.2);
+}
+
+textarea {
+  resize: vertical;
+}
+
+button {
+  border-radius: 999px;
+  border: none;
+  padding: 0.7rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+button[type="submit"],
+button.primary {
+  background: linear-gradient(135deg, var(--primary), #5a88f0);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 10px 25px rgba(37, 92, 199, 0.2);
+}
+
+button.secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(37, 92, 199, 0.3);
+  outline-offset: 2px;
+}
+
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+button:hover {
+  transform: translateY(-1px);
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.controls__label {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.controls input {
+  width: 180px;
+}
+
+.history-header {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 720px) {
+  .history-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.history-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.day-group {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f8faff;
+}
+
+.day-group__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.day-group__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.day-group__count {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 92, 199, 0.15);
+  color: var(--primary-dark);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.event-card {
+  background: white;
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  margin-top: 0.7rem;
+  border: 1px solid rgba(37, 92, 199, 0.1);
+  box-shadow: 0 6px 16px rgba(37, 92, 199, 0.08);
+}
+
+.event-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.event-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.event-delete {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  align-self: flex-start;
+}
+
+.event-delete:hover,
+.event-delete:focus-visible {
+  background: rgba(37, 92, 199, 0.08);
+  color: var(--primary-dark);
+}
+
+.event-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.event-time {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.event-details {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--muted);
+}
+
+.empty-state strong {
+  display: block;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+footer {
+  margin-top: auto;
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--muted);
+}
+
+
+#auth-dialog {
+  width: min(420px, 90%);
+  border: none;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+#auth-dialog::backdrop {
+  background: rgba(27, 33, 45, 0.45);
+}
+
+.auth-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+#auth-message {
+  margin: 0.5rem 0 0;
+  color: #b42318;
+  font-weight: 600;
+  min-height: 1.25rem;
+}
+#export-dialog {
+  width: min(520px, 90%);
+  border: none;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+#export-dialog::backdrop {
+  background: rgba(27, 33, 45, 0.45);
+}
+
+#export-output {
+  width: 100%;
+  margin: 1rem 0;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #f8faff;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.85rem;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -208,6 +208,12 @@ button:hover {
   background: #f8faff;
 }
 
+.day-group--selected {
+  border-color: var(--primary);
+  background: #eef3ff;
+  box-shadow: 0 0 0 2px rgba(37, 92, 199, 0.1);
+}
+
 .day-group__header {
   display: flex;
   justify-content: space-between;
@@ -234,6 +240,11 @@ button:hover {
   color: var(--primary-dark);
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.badge--selected {
+  background: rgba(37, 92, 199, 0.25);
+  color: var(--primary);
 }
 
 .event-card {


### PR DESCRIPTION
## Summary
- add a lightweight sign-in experience with per-user storage and hashed passcodes
- disable journaling tools until a user is authenticated and show a friendly prompt when signed out
- enable deleting individual memories and refresh the UI styling to support the new controls

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d040675488832f96f74b0229d3ee27